### PR TITLE
Use relative paths for man page installations.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,6 @@ __version__ = os.getenv('VERSION', default='9999')
 
 cwd = os.getcwd()
 
-# Load EPREFIX from Portage, fall back to the empty string if it fails 
-try: 
-	from portage.const import EPREFIX 
-except ImportError: 
-	EPREFIX='/' 
-
 # Python files that need `__version__ = ""` subbed, relative to this dir:
 python_scripts = [os.path.join(cwd, path) for path in (
 	'esearch/__init__.py',
@@ -80,9 +74,9 @@ core.setup(
 	packages=packages,
 	scripts=(glob('bin/*')),
 	data_files=(
-		(os.path.join(EPREFIX, 'usr/share/man/man1'), glob('man/en/*')),
-		(os.path.join(EPREFIX, 'usr/share/man/fr/man1'), glob('man/fr/*')),
-		(os.path.join(EPREFIX, 'usr/share/man/it/man1'), glob('man/it/*')),
+		(os.path.join('share/man/man1'), glob('man/en/*')),
+		(os.path.join('share/man/fr/man1'), glob('man/fr/*')),
+		(os.path.join('share/man/it/man1'), glob('man/it/*')),
 	),
 	cmdclass={
 		'set_version': set_version,


### PR DESCRIPTION
Fixes bug where `EPREFIX=''` (the default), causes man pages to be installed in to `/usr/usr/share/man` due to non-anchored paths.

This bug affects `app-portage/esearch-{1.0{,-r1},9999}`, so if you merge the pull request I won't need to open a bug report that seems to get assigned to you anyway ;)

Thanks,

James
