### PR TITLE
Update to sync.py for python3 support

### DIFF
--- a/esearch/sync.py
+++ b/esearch/sync.py
@@ -247,7 +247,7 @@ def sync(config):
 
     # alphabetic sort
     items = list(new.items())
-    items.sort(lambda x, y: cmp(x[0], y[0]))
+    items.sort(key=lambda x: x[0])
 
     old_keys = list(old.keys())
 


### PR DESCRIPTION
The syntax of sort has changed in py3, now you don't specify a (lambda) function for comparing two items, but a sort key. The change is compatible with python2.
