### PR TITLE
Python3-fix in update.py

### DIFF
--- a/esearch/update.py
+++ b/esearch/update.py
@@ -80,7 +80,7 @@ def getfetchsize(pkg):
             fetchlist = portage.portdb.getfetchlist(pkg,
                 mysettings=portage.settings, all=True)[1]
         mysum = mf.getDistfilesSize(fetchlist)
-        mystr = str(mysum/1024)
+        mystr = str(mysum // 1024)
         mycount = len(mystr)
         while (mycount > 3):
             mycount -= 3


### PR DESCRIPTION
The /-operator of python3 now uses float divison even if the inputs are integers, so we have to explicitly state that we want to use integer divison by using // instead of /. This change is compatible to python2.
