### PR TITLE
Bug: Undefined variable in sync()

### DIFF
--- a/esearch/sync.py
+++ b/esearch/sync.py
@@ -192,6 +192,8 @@ def layman_sync(config):
 
 def sync(config):
 
+    warnings = None
+
     tree_old = gettree("old", config)
 
     if config['layman-sync']:


### PR DESCRIPTION
The variable 'warnings' in sync() is undefined if esync is called
without --layman-sync. This causes esync to fail when executing the
'if warnings ...' statement.
